### PR TITLE
Development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a **pnpm workspaces + Turborepo monorepo** (`@dune2` scope) containing:
+
+- `@dune2/tools` — React utility library (state, storage, i18n, number formatting, React Query wrappers)
+- `@dune2/cli` — CLI for generating TypeScript API clients from Swagger/OpenAPI specs
+- `@dune2/babel` — Babel utilities for AST-based store creation
+- `docs` — Next.js documentation site (Fumadocs)
+
+No databases, Docker, or external services are required. All tests are self-contained Vitest unit tests.
+
+### Key commands
+
+See `package.json` scripts at the root. Summary:
+
+| Task               | Command                   |
+| ------------------ | ------------------------- |
+| Install deps       | `pnpm install`            |
+| Build all packages | `pnpm run build`          |
+| Run all tests      | `pnpm run test`           |
+| Format check       | `pnpm run format:check`   |
+| Auto-format        | `pnpm run format`         |
+| Docs dev server    | `cd docs && pnpm run dev` |
+
+### Gotchas
+
+- **Node.js v24** is required (see `.nvmrc`). Use `nvm use 24` before running commands.
+- **Build before test**: Turborepo's `test` task depends on `build` (see `turbo.json`), so `pnpm run test` will build first automatically.
+- **Catalog syntax bug**: The `catalog:@types/debug` and `catalog:tsdown` entries in `packages/babel/package.json` and `packages/cli/package.json` are invalid pnpm catalog syntax (should be `catalog:`). This has been fixed in the environment setup commit. If you encounter `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC`, verify these entries use `catalog:` (not `catalog:package-name`).
+- **sharp build warning**: pnpm may warn about ignored `sharp` build scripts. This is non-blocking; `sharp` has been added to `onlyBuiltDependencies` in `pnpm-workspace.yaml`.
+- The `@dune2/tools` package exports source `.ts`/`.tsx` files directly (no dist output), so the turbo warning about missing output files for `@dune2/tools#build` is expected.

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -41,8 +41,8 @@
     "@types/babel__core": "^7.20.1",
     "@types/babel__generator": "^7.6.8",
     "@types/babel__traverse": "^7.20.6",
-    "@types/debug": "catalog:@types/debug",
+    "@types/debug": "catalog:",
     "prettier": "^3.8.1",
-    "tsdown": "catalog:tsdown"
+    "tsdown": "catalog:"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,9 +47,9 @@
     "p-map": "^7.0.4"
   },
   "devDependencies": {
-    "@types/debug": "catalog:@types/debug",
+    "@types/debug": "catalog:",
     "openapi-types": "^12.0.2",
     "prettier": "^3.8.1",
-    "tsdown": "catalog:tsdown"
+    "tsdown": "catalog:"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - 'docs'
 onlyBuiltDependencies:
   - lefthook
+  - sharp
 ignoredBuiltDependencies:
   - esbuild
 catalog:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix pnpm dependency resolution issues and add development environment setup instructions to enable successful local development.

The `catalog:@types/debug` and `catalog:tsdown` syntax in `package.json` files was a known pnpm bug where `pnpm add` incorrectly wrote `catalog:package-name` instead of `catalog:`. These references were corrected to allow `pnpm install` to succeed. Additionally, `sharp` was added to `onlyBuiltDependencies` to address a build warning in the docs package. `AGENTS.md` was created to document the development environment setup.

<div><a href="https://cursor.com/agents/bc-b22ce178-0ba8-4195-8698-5dc4ff2d407c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b22ce178-0ba8-4195-8698-5dc4ff2d407c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->