### PR TITLE
refactor(cli): replace json schema type generator

### DIFF
--- a/.changeset/wet-needles-study.md
+++ b/.changeset/wet-needles-study.md
@@ -1,0 +1,5 @@
+---
+'@dune2/cli': patch
+---
+
+Replace `json-schema-to-typescript` with `@fumari/json-schema-ts` for API type generation.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,12 +41,12 @@
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^12.1.0",
+    "@fumari/json-schema-ts": "^1.0.2",
     "cac": "^7.0.0",
     "debug": "^4.4.3",
     "enquirer": "^2.3.6",
     "es-toolkit": "catalog:",
     "jiti": "^2.6.1",
-    "json-schema-to-typescript": "15.0.3",
     "p-map": "^7.0.4"
   },
   "devDependencies": {

--- a/packages/cli/src/commands/generateApi/index.ts
+++ b/packages/cli/src/commands/generateApi/index.ts
@@ -4,8 +4,8 @@ import fs from 'node:fs/promises';
 import * as os from 'os';
 import path from 'path';
 import SwaggerParser from '@apidevtools/swagger-parser';
+import { generate } from '@fumari/json-schema-ts';
 import { camelCase, isPlainObject, merge } from 'es-toolkit';
-import { compile } from 'json-schema-to-typescript';
 import type { OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 import pMap from 'p-map';
 import { createLogger } from '../../shared';
@@ -188,7 +188,7 @@ async function fetchRemoteDocument(
  * 构造一个最小化的定义上下文。
  *
  * 之前是把整个 components/definitions 直接挂到每个待编译的 schema 上，
- * 导致 json-schema-to-typescript 每次 compile 都要遍历整份 API 的类型图，
+ * 导致类型生成器每次都要遍历整份 API 的类型图，
  * 261 个接口 × 2（Req/Res）= 522 次全量遍历，非常慢。
  * 这里改为按需收集可达定义，输出结果不变，但速度大幅提升。
  */
@@ -372,8 +372,7 @@ export async function generateApi() {
         : apiConfig.swaggerJSONPath;
       parsed = await parser.bundle(bundleInput, dereferenceConfig);
       // default 值经常和 type 不一致（例如 integer + ""），
-      // 会被 json-schema-to-typescript 推断成交叉类型（number & string）。
-      // 生成前统一移除 default，避免污染类型。
+      // 生成前统一移除，避免输出错误的类型或文档。
       stripDefaultKeywordDeep(parsed);
       log.info(
         '解析 %s 成功，耗时 %dms',
@@ -706,14 +705,8 @@ async function compileRequestParams(
   let code = '';
   if (finalSchema) {
     try {
-      code = await compile(finalSchema as never, 'Req', {
-        bannerComment: '',
-        ignoreMinAndMaxItems: !!1,
-        additionalProperties: false,
-        unknownAny: false,
-        // 生成完成后会统一用 codeFormatterCmd 格式化，
-        // 这里关闭内置 prettier，避免每个类型都跑一次格式化拖慢速度。
-        format: false,
+      code = generate(finalSchema as never, {
+        name: 'Req',
       });
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
@@ -775,14 +768,8 @@ async function compileResponseParams(
   let code = '';
   if (finalSchema) {
     try {
-      code = await compile(finalSchema, 'Res', {
-        bannerComment: '',
-        ignoreMinAndMaxItems: !!1,
-        additionalProperties: false,
-        unknownAny: false,
-        // 生成完成后会统一用 codeFormatterCmd 格式化，
-        // 这里关闭内置 prettier，避免每个类型都跑一次格式化拖慢速度。
-        format: false,
+      code = generate(finalSchema as never, {
+        name: 'Res',
       });
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);

--- a/packages/cli/tests/__snapshots__/generateByOperationObject.spec.ts.snap
+++ b/packages/cli/tests/__snapshots__/generateByOperationObject.spec.ts.snap
@@ -13,106 +13,73 @@ export const usersPostApi = new RequestBuilder<usersPostApi.Req, usersPostApi.Re
 });
 
 export namespace usersPostApi {
- /**
- * 分页查询统一结构体
- */
+ /** 分页查询统一结构体 */
 export interface Req {
-/**
- * 页码数，该值的范围是 1~1024
- */
-pageNum: number
-/**
- * 页大小，该值的范围是 1~99999
- */
-pageSize: number
-/**
- * 是否查询总记录数。查询总记录数会严重影响性能，非必要不查询。
- */
-count: boolean
-/**
- * 币种列表查询参数
- */
-params: {
-/**
- * 币种代码或者币种名称
- */
-nameOrCode?: string
-/**
- * 币种状态 (NEW, ACTIVE, INACTIVE)
- */
-status?: ("NEW" | "ACTIVE" | "INACTIVE")
-}
-/**
- * 分页查询的排序规则，最大不能超过 10 个排序字段
- * 
- * @minItems 0
- * @maxItems 10
- */
-orders?: {
-/**
- * 字段名称
- */
-fieldName: string
-/**
- * 排序规则
- */
-type: ("asc" | "desc")
-}[]
+  /** 页码数，该值的范围是 1~1024 */
+  pageNum: number;
+
+  /** 页大小，该值的范围是 1~99999 */
+  pageSize: number;
+
+  /** 是否查询总记录数。查询总记录数会严重影响性能，非必要不查询。 */
+  count: boolean;
+
+  /** 币种列表查询参数 */
+  params: {
+    /** 币种代码或者币种名称 */
+    nameOrCode?: string;
+
+    /** 币种状态 (NEW, ACTIVE, INACTIVE) */
+    status?: "NEW" | "ACTIVE" | "INACTIVE";
+  };
+
+  /** 分页查询的排序规则，最大不能超过 10 个排序字段 */
+  orders?: {
+    /** 字段名称 */
+    fieldName: string;
+
+    /** 排序规则 */
+    type: "asc" | "desc";
+  }[];
 }
 
  
- /**
- * 分页查询结果统计结构体
- */
+ /** 分页查询结果统计结构体 */
 export interface Res {
-payload?: any
-/**
- * 总记录数。如果请求参数中'是否查询总记录数'为 true 则此参数将会返回。
- */
-total?: number
-/**
- * 分页查询的结果
- */
-result: {
-/**
- * 币种管理
- */
-coin?: {
-/**
- * 币种 id
- */
-id?: number
-/**
- * crypto 来源 Id，crypto_datasource 表的 Id
- */
-sourceId?: number
-/**
- * Coin 的名称，如：Bitcoin
- */
-name?: string
-/**
- * Coin 的符号，如：BTC
- */
-code?: string
-/**
- * 币种状态 (NEW,ACTIVE,INACTIVE)
- */
-status?: string
-}
-/**
- * 币种支持的网络
- */
-networks?: {
-/**
- * 表 Id，coin 唯一标识
- */
-id?: number
-/**
- * 币种的唯一标识，用于将网络关联到币种
- */
-coinId?: number
-}[]
-}[]
+  payload?: unknown;
+
+  /** 总记录数。如果请求参数中'是否查询总记录数'为 true 则此参数将会返回。 */
+  total?: number;
+
+  /** 分页查询的结果 */
+  result: {
+    /** 币种管理 */
+    coin?: {
+      /** 币种 id */
+      id?: number;
+
+      /** crypto 来源 Id，crypto_datasource 表的 Id */
+      sourceId?: number;
+
+      /** Coin 的名称，如：Bitcoin */
+      name?: string;
+
+      /** Coin 的符号，如：BTC */
+      code?: string;
+
+      /** 币种状态 (NEW,ACTIVE,INACTIVE) */
+      status?: string;
+    };
+
+    /** 币种支持的网络 */
+    networks?: {
+      /** 表 Id，coin 唯一标识 */
+      id?: number;
+
+      /** 币种的唯一标识，用于将网络关联到币种 */
+      coinId?: number;
+    }[];
+  }[];
 }
 
 };"
@@ -132,39 +99,27 @@ export const usersGetApi = new RequestBuilder<usersGetApi.Req, usersGetApi.Res>(
 
 export namespace usersGetApi {
  export interface Req {
-/**
- * 用户 id
- */
-id: number
+  /** 用户 id */
+  id: number;
 }
 
  
- /**
- * 查询用户响应结果
- */
+ /** 查询用户响应结果 */
 export interface Res {
-/**
- * agreement document payload
- */
-payload?: {
-[k: string]: any
-}
-/**
- * 用户 id
- */
-id?: number
-/**
- * 邮箱
- */
-email?: string
-/**
- * 姓名
- */
-realName?: string
-/**
- * 用户状态 (ACTIVE, INACTIVE)
- */
-status?: ("NEW" | "ACTIVE" | "INACTIVE")
+  /** agreement document payload */
+  payload?: unknown;
+
+  /** 用户 id */
+  id?: number;
+
+  /** 邮箱 */
+  email?: string;
+
+  /** 姓名 */
+  realName?: string;
+
+  /** 用户状态 (ACTIVE, INACTIVE) */
+  status?: "NEW" | "ACTIVE" | "INACTIVE";
 }
 
 };"
@@ -183,9 +138,7 @@ export const usersPostApi = new RequestBuilder<usersPostApi.Req, usersPostApi.Re
 });
 
 export namespace usersPostApi {
- export interface Req {
-
-}
+ export type Req = Record<string, unknown>;
 
  
  export type Res = any;
@@ -206,39 +159,27 @@ export const usersGetApi = new RequestBuilder<usersGetApi.Req, usersGetApi.Res>(
 
 export namespace usersGetApi {
  export interface Req {
-/**
- * 用户 id
- */
-id: number
+  /** 用户 id */
+  id: number;
 }
 
  
- /**
- * 查询用户响应结果
- */
+ /** 查询用户响应结果 */
 export interface Res {
-/**
- * agreement document payload
- */
-payload?: {
-[k: string]: any
-}
-/**
- * 用户 id
- */
-id?: number
-/**
- * 邮箱
- */
-email?: string
-/**
- * 姓名
- */
-realName?: string
-/**
- * 用户状态 (ACTIVE, INACTIVE)
- */
-status?: ("NEW" | "ACTIVE" | "INACTIVE")
+  /** agreement document payload */
+  payload?: unknown;
+
+  /** 用户 id */
+  id?: number;
+
+  /** 邮箱 */
+  email?: string;
+
+  /** 姓名 */
+  realName?: string;
+
+  /** 用户状态 (ACTIVE, INACTIVE) */
+  status?: "NEW" | "ACTIVE" | "INACTIVE";
 }
 
 };"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       '@apidevtools/swagger-parser':
         specifier: ^12.1.0
         version: 12.1.0(openapi-types@12.1.3)
+      '@fumari/json-schema-ts':
+        specifier: ^1.0.2
+        version: 1.0.2
       cac:
         specifier: ^7.0.0
         version: 7.0.0
@@ -199,9 +202,6 @@ importers:
       jiti:
         specifier: ^2.6.1
         version: 2.7.0
-      json-schema-to-typescript:
-        specifier: 15.0.3
-        version: 15.0.3
       p-map:
         specifier: ^7.0.4
         version: 7.0.4
@@ -264,10 +264,6 @@ importers:
         version: 8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.0)
 
 packages:
-
-  '@apidevtools/json-schema-ref-parser@11.9.3':
-    resolution: {integrity: sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==}
-    engines: {node: '>= 16'}
 
   '@apidevtools/json-schema-ref-parser@14.0.1':
     resolution: {integrity: sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==}
@@ -868,6 +864,14 @@ packages:
       tailwindcss:
         optional: true
 
+  '@fumari/json-schema-ts@1.0.2':
+    resolution: {integrity: sha512-1NHGl8Oqg50mhpWMvbhqnwFRLBugkGCRubLSH/TrAzTAS99x4z0xFgOVcbJne+yfaZv94ZNdmRWobDvUiZswPg==}
+    peerDependencies:
+      json-schema-typed: '*'
+    peerDependenciesMeta:
+      json-schema-typed:
+        optional: true
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -1029,9 +1033,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@jsdevtools/ono@7.1.3':
-    resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -2240,9 +2241,6 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/lodash@4.17.17':
-    resolution: {integrity: sha512-RRVJ+J3J+WmyOTqnz3PiBLA501eKwXl2noseKOrNo/6+XEHjTAxO4xHvxQB6QuNm+s4WRbn6rSiap8+EA+ykFQ==}
-
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -2989,11 +2987,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  json-schema-to-typescript@15.0.3:
-    resolution: {integrity: sha512-iOKdzTUWEVM4nlxpFudFsWyUiu/Jakkga4OZPEt7CGoSEsAsUgdOZqR6pcgx2STBek9Gm4hcarJpXSzIvZ/hKA==}
-    engines: {node: '>=16.0.0'}
-    hasBin: true
-
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -3135,9 +3128,6 @@ packages:
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -3324,9 +3314,6 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
-
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   motion-dom@12.40.0:
     resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
@@ -4201,12 +4188,6 @@ packages:
 
 snapshots:
 
-  '@apidevtools/json-schema-ref-parser@11.9.3':
-    dependencies:
-      '@jsdevtools/ono': 7.1.3
-      '@types/json-schema': 7.0.15
-      js-yaml: 4.2.0
-
   '@apidevtools/json-schema-ref-parser@14.0.1':
     dependencies:
       '@types/json-schema': 7.0.15
@@ -4754,6 +4735,8 @@ snapshots:
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
 
+  '@fumari/json-schema-ts@1.0.2': {}
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -4876,8 +4859,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@jsdevtools/ono@7.1.3': {}
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -5970,8 +5951,6 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/lodash@4.17.17': {}
-
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -6756,18 +6735,6 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  json-schema-to-typescript@15.0.3:
-    dependencies:
-      '@apidevtools/json-schema-ref-parser': 11.9.3
-      '@types/json-schema': 7.0.15
-      '@types/lodash': 4.17.17
-      is-glob: 4.0.3
-      js-yaml: 4.2.0
-      lodash: 4.17.21
-      minimist: 1.2.8
-      prettier: 3.8.1
-      tinyglobby: 0.2.17
-
   json-schema-traverse@1.0.0: {}
 
   json5@2.2.3: {}
@@ -6873,8 +6840,6 @@ snapshots:
       p-locate: 4.1.0
 
   lodash.startcase@4.4.0: {}
-
-  lodash@4.17.21: {}
 
   longest-streak@3.1.0: {}
 
@@ -7329,8 +7294,6 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
-
-  minimist@1.2.8: {}
 
   motion-dom@12.40.0:
     dependencies:


### PR DESCRIPTION
## Why

`generateApi` invokes the schema generator once for each request and response type, so generator overhead is multiplied across an OpenAPI document. `@fumari/json-schema-ts` provides the `$ref` and named-root generation we need with a synchronous API and no runtime dependencies.

## Summary

- replace `json-schema-to-typescript` with `@fumari/json-schema-ts`
- migrate request and response type generation to `generate(schema, { name })`
- retain the existing reachable-`$ref` optimization for OpenAPI 2 `definitions` and OpenAPI 3 `components.schemas`
- update generated-code snapshots and add a patch changeset

## Size and dependency comparison

Measured from the npm registry and clean, isolated pnpm installs:

| Metric | `json-schema-to-typescript@15.0.3` | `@fumari/json-schema-ts@1.0.2` | Change |
| --- | ---: | ---: | ---: |
| Direct runtime dependencies | 9 | 0 | -9 |
| npm tarball | 48,333 B (47.2 KiB) | 22,115 B (21.6 KiB) | -54.2% |
| npm-reported unpacked package | 200,802 B (196.1 KiB) | 77,864 B (76.0 KiB) | -61.2% |
| Isolated pnpm `node_modules` | 18,587 KiB | 104 KiB | -99.4% |
| Installed pnpm package entries | 15 | 1 | -14 |

The old dependency tree includes Prettier, Lodash, `json-schema-ref-parser`, `js-yaml`, and CLI helpers. The replacement has only an optional `json-schema-typed` peer, which is not required at runtime.

## Generation benchmark

Synthetic microbenchmark on the same orb:

- Node.js 24.18.0, Linux x64, Intel Xeon @ 2.60 GHz
- one object schema containing an array union over 20 local `$ref` definitions
- each referenced model contains required fields, optional fields, and an array
- 100 warm-up generations, followed by 5 samples × 1,000 sequential generations
- old generator uses the same production options, including `format: false`; new generator uses `{ name: 'Response' }`

| Generator | Median / 1,000 | Per generation | Throughput |
| --- | ---: | ---: | ---: |
| `json-schema-to-typescript` | 3,796.1 ms | 3.796 ms | ~263 ops/s |
| `@fumari/json-schema-ts` | 110.9 ms | 0.111 ms | ~9,017 ops/s |

In this ref-heavy workload, the replacement is **34.2× faster**. This is intentionally reported as a generator microbenchmark rather than an end-to-end OpenAPI benchmark; actual CLI gains depend on schema shape, I/O, and the number of generated operations.

Raw samples (milliseconds per 1,000 generations):

- old: `3796.1, 3756.8, 3751.9, 3883.1, 3801.6`
- new: `130.6, 112.7, 110.9, 106.3, 108.2`

## Output changes / trade-offs

- unconstrained schemas now generate `unknown` instead of `any`, improving type safety but making generated consumers stricter
- empty object requests generate `Record<string, unknown>`
- generated declarations use normalized indentation and semicolons
- schema constraints such as `minItems`/`maxItems` are not emitted as JSDoc by the new generator
- existing tests confirm named `Req`/`Res` roots and OpenAPI 2 `definitions` reference generation still work

## Verification

- `pnpm --filter @dune2/cli test` — 11 tests passed
- `pnpm --filter @dune2/cli lint`
- `pnpm --filter @dune2/cli build`
- `pnpm exec oxfmt --check packages/cli/src/commands/generateApi/index.ts packages/cli/package.json packages/cli/tests/__snapshots__/generateByOperationObject.spec.ts.snap .changeset/wet-needles-study.md`
